### PR TITLE
LC-10309

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -43,9 +43,11 @@ use Cpanel::RPM             ();
 
 use Cpanel::Imports;
 
-our $IMUNIFY360_PRODUCT_ID            = 'IMUNIFY360';          # TODO: Update this string as needed
-our $IMUNIFY360_PACKAGE_ID_RE         = qr/\bIMUNIFY360\b/;    # TODO: Verify that this is correct
-our $IMUNIFY360_MINIMUM_CPWHM_VERSION = '11.79';               # we want it usable on both development and release builds for 11.80
+our $IMUNIFY360_MINIMUM_CPWHM_VERSION = '11.79';    # we want it usable on both development and release builds for 11.80
+
+# These two ids were verified as correct 2019-02-11 using https://verify.cpanel.net/api/addons?ip=...... for a licensed IP address
+our $IMUNIFY360_PRODUCT_ID    = 'Imunify360';
+our $IMUNIFY360_PACKAGE_ID_RE = qr/\bIMUNIFY360\b/;    # e.g., PARTNERNAME-IMUNIFY360-UNLIMITED or ANOTHERNAME-IMUNIFY360-SOLO
 
 # These two short names were verified as correct 2019-02-08 using https://aa.store.manage.testing.cpanel.net/
 our $IMUNIFY360_STORE_SHORTNAME_UNL  = 'monthly_imunify360_unlimited';


### PR DESCRIPTION
Case LC-10309: The values that were here before were placeholders
based on some internal documentation that didn't have everything we
needed. Now that we've seen a sample of the real data, the product
id check has been updated to match reality.

The product id is 'Imunify360' (not all caps).

The package id follows the format [PROVIDER]-IMUNIFY360-[TYPE],
so the check for \bIMUNIFY360\b was already good enough, although
somewhat redundant with the product id check.